### PR TITLE
Add support for tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .coverage
 .ropeproject
 .venv
+.tox
 *.sublime-*
 build
 dist

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py26, py27
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+commands = nosetests {posargs}


### PR DESCRIPTION
```
 ❯ tox
GLOB sdist-make: /Users/marca/dev/git-repos/gsocketpool/setup.py
py26 inst-nodeps: /Users/marca/dev/git-repos/gsocketpool/.tox/dist/gsocketpool-0.1.2.zip
py26 runtests: commands[0] | nosetests
.......................
----------------------------------------------------------------------
Ran 23 tests in 2.992s

OK
py27 inst-nodeps: /Users/marca/dev/git-repos/gsocketpool/.tox/dist/gsocketpool-0.1.2.zip
py27 runtests: commands[0] | nosetests
.......................
----------------------------------------------------------------------
Ran 23 tests in 2.893s

OK
___________________________________________________________________________________ summary ____________________________________________________________________________________
  py26: commands succeeded
  py27: commands succeeded
  congratulations :)
```
