### PR TITLE
python3 support

### DIFF
--- a/gsocketpool/__init__.py
+++ b/gsocketpool/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from connection import Connection
-from connection import TcpConnection
-from pool import Pool
-from exceptions import ConnectionNotFoundError, PoolExhaustedError
+from __future__ import absolute_import
+
+from gsocketpool.connection import Connection
+from gsocketpool.connection import TcpConnection
+from gsocketpool.pool import Pool
+from gsocketpool.exceptions import ConnectionNotFoundError, PoolExhaustedError

--- a/gsocketpool/pool.py
+++ b/gsocketpool/pool.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import collections
 import logging
 import contextlib
 import gevent
 from gevent import Greenlet
 
-from exceptions import ConnectionNotFoundError, PoolExhaustedError
+from gsocketpool.exceptions import ConnectionNotFoundError, PoolExhaustedError
 
 
 class ConnectionReaper(Greenlet):


### PR DESCRIPTION
It seems like this is the only change that is needed for Python3 support. All tests passes on both Python 2.7.10 and Python 3.5.0.

The `from __future__ import absolute_import` is not needed but I added it for clarity.